### PR TITLE
Add database and cache followers and friends

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -130,3 +130,4 @@ dmypy.json
 
 .idea/
 settings_prod.py
+data_access_layer/.alt_bot_data.db

--- a/README.md
+++ b/README.md
@@ -13,8 +13,9 @@
 
 Currently, the logic goes like follows:
 
- * Some Twitter accounts are configured to be followed, check in `settings.ACCOUNTS_TO_CHECK`. 
- * Each time a new tweet is published and the bot reads it, checks for images with alt_text
+ * Some Twitter accounts are followed by the bot (friends) and some tweeter users follow the bot (followers). 
+ * Periodically, the bot checks for new tweets from both, friends or followers, and checks its last tweets 
+ for images with alt_text
      * if the tweet doesn't contain images, nothing is done
      * if the tweet contains images, and for all of them an alt_text is given, then it is faved
      * if the tweet contains images without any alt_text, then it depends if it is a Follower or a Friend:
@@ -59,28 +60,36 @@ currently in production (prod branch). Some of them are closed issues in master,
  * Current version add timestamp to log file
  * Messages are are now defined in `bot_messages.py` module, and include a link to a tutorial on how to add alt_text 
  to images.  
+ 
+ ## V1.2
+[master] Those changes are to put into production next Monday 19th April, after notifying followers with a DM on changes.
+ * Add a SQLITE database to save processed tweets, followers and friends, making the bot far more efficient  
+ * Follow users with private content when tweets can not be read
+ * Send DM to maintainer in case of unexpected error
+ * Include arg parse to run the bot easier with different use cases
+ * Implement broadcast message to followers to share news on the bot
     
 # ROAD MAP (prioritized):
  * ~~**IMPROVEMENT**: Read the following list and use this instead of the `settings.ACCOUNTS_TO_CHECK`.~~
  * ~~**IMPROVEMENT**: crontab based local deploy, run it once a day~~
- * **IMPROVEMENT**: Follow back followers whose tweets can't be read.
+ * ~~**IMPROVEMENT**: Follow back followers whose tweets can't be read.~~
  * **IMPROVEMENT**: Currently, last `settings.LAST_N_TWEETS` (10) are retrieved from tweeter for the configured accounts, 
   then each of them is checked in our local database to see if it was already processed. This is inefficient. 
   We only need to retrieve new tweets since last download to avoid duplicates.
- * **USE CASE**: Add logs to track alt_text usage and later analise how it evolves
- * **IMPROVEMENT**: Include a real database to account for already processed tweets, dockerized if possible
- * **IMPROVEMENT**: Add DataBase management module
- * **IMPROVEMENT**: Add Tweeter API management module
+ * ~~**USE CASE**: Add logs to track alt_text usage and later analise how it evolves~~
+ * ~~**IMPROVEMENT**: Include a real database to account for already processed tweets, dockerized if possible~~
+ * ~~**IMPROVEMENT**: Add DataBase management module~~
  * ~~**IMPROVEMENT**: Modify loggs format to include timestamp~~
+ * ~~**IMPROVEMENT**: Add argparse to give parameters easier~~
+ * ~~**USE CASE**: Add a service for followers to friendly remind them by DM instead of by public tweets~~
  * **IMPROVEMENT**: Web page, possibly as [github io page](https://pages.github.com/), in Spanish
+ * **IMPROVEMENT**: Add Tweeter API management module (current is too coupled)
  * **IMPROVEMENT**: Tutorial on how to include alt_texts on images. Tweeter thread / page article, spanish
  * **IMPROVEMENT**: Importance of alt_texts on images. Tweeter thread / page article, spanish
  * **IMPROVEMENT**: Add a "terms of use" or privacy section thread/page
  * **IMPROVEMENT**: Add an about the project section thread/page
- * **IMPROVEMENT**: Add argparse to give parameters easier
  * **IMPROVEMENT**: dockerize current solution
  * **IMPROVEMENT**: improve deploy to be available all time, remotely hosted
- * ~~**USE CASE**: Add a service for followers to friendly remind them by DM instead of by public tweets~~
  * **IMPROVEMENT**: Improve the manage of tweeter credentials
  * **COMPLEMENT**: OCR module, based *probably* in tesseract, spanish output
  * **COMPLEMENT**: image captioning module, spanish output. Initially migth be based on Azure: Caption module in 
@@ -100,6 +109,27 @@ Requirements can be installed with `pip install -r requirements.txt`, developed 
  
 Also need to provide the appropiated credentials to connect with Twitter, defined in `settings.py`. The interaction with twitter is done throgth tweepy API. 
 [Here](https://realpython.com/twitter-bot-python-tweepy/#using-tweepy) you can find a complete tutorial on this API.
+
+## running the bot
+
+Information on how to run can be checked with `help` command, as follows:
+
+```.env
+$  python altBot_main.py --help                                                                                                                                         3643  17:14:03  
+usage: altBot_main.py [-h] [-u] [-w] [-m MESSAGE]
+
+This script runs AltBotUY.
+
+optional arguments:
+  -h, --help            show this help message and exit
+  -u, --update-users    Update the local list of followers and friends
+  -w, --watch-alt-texts
+                        Run the watch-alt-text use case
+  -m MESSAGE, --message MESSAGE
+                        Send given message to followers. Can also be the path
+                        to a text file containing the message
+
+```
 
 # Related work:
 

--- a/data_access_layer/data_access.py
+++ b/data_access_layer/data_access.py
@@ -1,0 +1,143 @@
+import logging
+import sqlite3
+from datetime import datetime
+from typing import Set, Tuple
+
+from data_access_layer import db_queries
+from settings import DB_FILE
+
+
+class DBAccess:
+
+    def __init__(self, db_file: str = DB_FILE):
+
+        self.db_file = db_file
+        self.connection = sqlite3.connect(db_file)
+
+        if self.connection is None:
+            raise Exception(f'Cannot connect with database {DB_FILE}')
+
+        self.create_tables()
+
+    def __del__(self):
+        if hasattr(self, 'connection'):
+            self.connection.close()
+
+    def create_tables(self) -> None:
+        """
+        This method allows to create tables needed to store processed tweets
+        :return: None
+        """
+        self.connection.execute(db_queries.CREATE_PROCESSED_TWEETS_TABLE)
+        self.connection.execute(db_queries.CREATE_PROCESSED_TWEETS_ALT_TEXT_INFO_TABLE)
+        self.connection.execute(db_queries.CREATE_FRIENDS_TWEETS_TABLE)
+        self.connection.execute(db_queries.CREATE_FOLLOWERS_TABLE)
+
+    def save_processed_tweet_with_with_alt_text_info(self, screen_name: str, user_id: int, tweet_id: str, n_images: int,
+                                                     alt_score: float, follower: bool, friend: bool) -> None:
+        """
+        Stores the data related to processed tweets with images, needed to implement reports on alt_text usage
+        :param screen_name: screen_name of user who wrote the tweet
+        :param user_id: id of user who wrote the tweet
+        :param tweet_id: id of the tweet
+        :param n_images: number of images attached to the tweet
+        :param alt_score: portion of attached images containing alt_text
+        :param follower: True iff the user is a follower of the bot, when tweet is processed
+        :param friend: True iff the user is a friend of the bot, when tweet is processed
+        :return: None
+        """
+        processed_at = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
+        #
+        self.connection.execute(db_queries.SAVE_TWEET_ALT_TEXT_INFO,
+                                (tweet_id, screen_name, user_id, n_images, alt_score,
+                                 processed_at, int(friend), int(follower)))
+        self.connection.commit()
+
+    def save_processed_tweet(self, tweet_id: str) -> None:
+        """
+        Stores the id of processed tweet, no matter if contains images or not
+        :param tweet_id: id of a processed tweet
+        :return: None
+        """
+        self.connection.execute(db_queries.SAVE_PROCESSED_TWEET, (tweet_id,))
+        self.connection.commit()
+
+    def tweet_was_processed(self, tweet_id: str) -> bool:
+        """
+        Check whether or not the given tweet was processed
+        :param tweet_id: id of the tweet to be checked
+        :return: True iff the tweet already exist on db
+        """
+        res = self.connection.execute(db_queries.CHECK_TWEET_PROCESSED, (tweet_id,)).fetchone()[0]
+        return bool(res)
+
+    def get_friends(self) -> Set[Tuple[str, int]]:
+        return {(row[0], row[1]) for row in self.connection.execute(db_queries.GET_FRIENDS)}
+
+    def get_followers(self) -> Set[Tuple[str, int]]:
+        return {(row[0], row[1]) for row in self.connection.execute(db_queries.GET_FOLLOWERS)}
+
+    def update_friends(self, new_friends: Set[Tuple[str, int]], lost_friends: Set[Tuple[str, int]]) -> None:
+
+        for friend_name, friend_id in lost_friends:
+            try:
+                self.connection.execute(db_queries.REMOVE_FRIEND, (friend_id,))
+            except sqlite3.IntegrityError as ie:
+                logging.error(f'Can not remove friend {friend_name}: {ie}')
+
+        for friend_name, friend_id in new_friends:
+            try:
+                self.connection.execute(db_queries.ADD_FRIEND, (friend_name, friend_id))
+            except sqlite3.IntegrityError as ie:
+                logging.error(f'Can not add friend {friend_name}: {ie}')
+
+        self.connection.commit()
+
+    def update_followers(self, new_followers: Set[Tuple[str, int]], followers: Set[Tuple[str, int]]) -> None:
+
+        for follower_name, follower_id in followers:
+            try:
+                self.connection.execute(db_queries.REMOVE_FOLLOWER, (follower_id,))
+            except sqlite3.IntegrityError as ie:
+                logging.error(f'Can not remove follower {follower_name}: {ie}')
+
+        for follower_name, follower_id in new_followers:
+            try:
+                self.connection.execute(db_queries.ADD_FOLLOWER, (follower_name, follower_id))
+            except sqlite3.IntegrityError as ie:
+                logging.error(f'Can not add follower {follower_name}: {ie}')
+
+        self.connection.commit()
+
+    def count_followers(self) -> int:
+        return self.connection.execute(db_queries.COUNT_FOLLOWERS).fetchone()[0]
+
+    def count_friends(self) -> int:
+        return self.connection.execute(db_queries.COUNT_FRIENDS).fetchone()[0]
+
+
+if __name__ == '__main__':
+
+    db = DBAccess(f'../{DB_FILE}')
+    # db.save_processed_tweet('pepe4456')
+    # db.save_processed_tweet('pepe5')
+    # db.save_processed_tweet('pepe6')
+    #
+    # db.save_processed_tweet_with_with_alt_text_info('user_claudio123', 0, '00twit156', 3, 0., True, True)
+    # db.save_processed_tweet_with_with_alt_text_info('user_claudio123', 0, 'twit256', 4, 0.25, False, False)
+    # db.save_processed_tweet_with_with_alt_text_info('user_claudio123', 0, 'twit356', 4, 0.75, False, True)
+    # db.save_processed_tweet_with_with_alt_text_info('user_claudio123', 0, 'twit456', 4, 1, True, False)
+
+    # print(db.tweet_was_processed('pepe4'))
+    # print('='*10)
+    # print(db.tweet_was_processed('este no'))
+    #
+    # db.update_friends({('hola', 1), ('mundo',3)},  {('inexistente',2)})
+    # print(';'.join([str(s) for s in db.get_friends()]))
+    # print('='*10)
+    # db.update_followers({('sumado',123)}, {('mundo',2)})
+    # print(';'.join([f[0] for f in db.get_friends()]))
+    # print(';'.join([f[0] for f in db.get_followers()]))
+
+    print(db.count_followers())
+    print(db.count_friends())

--- a/data_access_layer/db_queries.py
+++ b/data_access_layer/db_queries.py
@@ -1,0 +1,65 @@
+
+CREATE_PROCESSED_TWEETS_TABLE = """
+ CREATE TABLE IF NOT EXISTS processed_tweets (
+                                        tweet_id TEXT PRIMARY KEY
+                                    );
+"""
+
+CREATE_PROCESSED_TWEETS_ALT_TEXT_INFO_TABLE = """
+ CREATE TABLE IF NOT EXISTS processed_tweets_alt_text_info (
+                                        tweet_id TEXT PRIMARY KEY,
+                                        screen_name TEXT, 
+                                        user_id INTEGER,
+                                        n_images INTEGER,
+                                        alt_score REAL,
+                                        processed_at TEXT,
+                                        friend INTEGER,
+                                        follower INTEGER 
+                                    );
+"""
+
+CREATE_FOLLOWERS_TABLE = """
+ CREATE TABLE IF NOT EXISTS followers (
+                                        screen_name TEXT,
+                                        user_id INT PRIMARY KEY
+                                    );
+"""
+
+CREATE_FRIENDS_TWEETS_TABLE = """
+ CREATE TABLE IF NOT EXISTS friends (
+                                        screen_name TEXT,
+                                        user_id INT PRIMARY KEY
+                                    );
+"""
+
+SAVE_PROCESSED_TWEET = """
+INSERT INTO processed_tweets (tweet_id) 
+      VALUES (?);
+"""
+
+SAVE_TWEET_ALT_TEXT_INFO = """
+INSERT INTO processed_tweets_alt_text_info (tweet_id, screen_name, user_id, n_images, 
+                                            alt_score, processed_at, friend, follower) 
+      VALUES (?, ?, ?, ?, ?, ?, ?, ?);
+"""
+
+GET_PROCESSED_TWEETS = "SELECT tweet_id from processed_tweets"
+
+CHECK_TWEET_PROCESSED = "SELECT EXISTS(SELECT 1 FROM processed_tweets WHERE tweet_id=?);"
+
+GET_FOLLOWERS = "SELECT screen_name, user_id from followers"
+
+GET_FRIENDS = "SELECT screen_name, user_id from friends"
+
+REMOVE_FRIEND = "DELETE FROM friends WHERE user_id=?"
+
+REMOVE_FOLLOWER = "DELETE FROM followers WHERE user_id=?"
+
+ADD_FRIEND = "INSERT INTO friends (screen_name, user_id) VALUES (?,?);"
+
+ADD_FOLLOWER = "INSERT INTO followers (screen_name, user_id) VALUES (?,?);"
+
+COUNT_FOLLOWERS = "SELECT Count() FROM followers"
+
+COUNT_FRIENDS = "SELECT Count() FROM friends"
+

--- a/settings.py
+++ b/settings.py
@@ -12,7 +12,6 @@ MAX_RECONNECTION_ATTEMPTS = 5
 
 ALT_BOT_NAME = 'AltBotUY'
 
-ACCOUNTS_TO_CHECK = ['ro_laguna_', 'raulsperoni', 'mili_costabel', 'bryant1410']
 LAST_N_TWEETS = 10
 
 LOG_LEVEL = logging.DEBUG

--- a/settings.py
+++ b/settings.py
@@ -15,6 +15,11 @@ ALT_BOT_NAME = 'AltBotUY'
 ACCOUNTS_TO_CHECK = ['ro_laguna_', 'raulsperoni', 'mili_costabel', 'bryant1410']
 LAST_N_TWEETS = 10
 
-PATH_TO_PROCESSED_TWEETS = 'processed_tweets.json'
 LOG_LEVEL = logging.DEBUG
 LOG_FILENAME = 'log/alt-bot-logs.log'
+
+DB_FILE = 'data_access_layer/.alt_bot_data.db'
+
+# credentials to send DM to mantainer, only for unexpected exceptions
+MAINTEINER_NAME = 'ro_laguna_'
+MAINTAEINER_ID = 537304416


### PR DESCRIPTION
[master] Those changes are to put into production next Monday 19th April, after notifying followers with a DM on changes.
 * Add a SQLITE database to save processed tweets, followers and friends, making the bot far more efficient  
 * Follow users with private content when tweets can not be read
 * Send DM to maintainer in case of unexpected error
 * Include arg parse to run the bot easier with different use cases
 * Implement broadcast message to followers to share news on the bot